### PR TITLE
Update en_US.lang

### DIFF
--- a/src/main/resources/assets/craftarcanum2/lang/en_US.lang
+++ b/src/main/resources/assets/craftarcanum2/lang/en_US.lang
@@ -1,6 +1,6 @@
 itemGroup.craftarcanum2=Craft Arcanum 2
 
-item.craftarcanum2.voxsonitus.name=Vox Sonitus
+item.craftarcanum2.voxsonitus.name=Vox Sonitu
 item.craftarcanum2.voxsonitus.desc=It echoes of a hundred songs once heard.
 item.craftarcanum2.voxsonitus.note=Note
 item.craftarcanum2.voxsonitus.tone=Tone


### PR DESCRIPTION
Thaumcraft contains too much fake Latin already. Please don't do that.

P.S.: I like the current name as it is. Yay Latin!
